### PR TITLE
add data_lock for shared data dict and stable async access 

### DIFF
--- a/etl/data.py
+++ b/etl/data.py
@@ -81,8 +81,9 @@ class Data:
 
         self.__data.update({key_name: data_record})
 
-    def clear(self, new_country_code) -> None:
-        self.__data.clear()
+    def set_country(self, new_country_code) -> None:
+        self.__data = {}
+        self.warnings: list[str] = []
         self.country = new_country_code
 
     @staticmethod


### PR DESCRIPTION
# Description:
add a lock for the data dict to prevent simultaneous access to it (and potential data loss)

Additionally Changes:
- not only the reference to the shared data dict but now the reference to the (whole) data_processor is injected to the pipeline to have also access to the locking mechanism
- the etl process was slightly adjusted and data (and warnings) are added to the shared dict in the last (loading) step now
