### PR TITLE
stop rerendering (fragment) after data loading completed

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -10,10 +10,10 @@ html, body, [class*="css"] {
     /* padding-bottom: 0;
 } */
 
-.main > div {
+[data-testid="stMainBlockContainer"] {
     padding-left: 2rem;
     padding-right: 2rem;
-    padding-top: 1rem;
+    padding-top: 2rem;
     padding-bottom: 1rem;
     background-color: #F8F8F8;
    


### PR DESCRIPTION
app was still  rerendering (fragment) after data loading completed

changes:
- added new session_state variable run_every and triggered rerun of app in render function  to load None into run_every of the decorator after data loaded (this does otherwise not update since decorator creation is not dynamic)